### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ testem.log
 .env
 hs_err*.log
 /apps/api/src/admin/
+/.nx
 
 # System Files
 .DS_Store

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kin-kinetic/sdk",
+  "name": "@kinny/kinetic-sdk",
   "version": "1.0.0-rc.18",
   "license": "MIT"
 }

--- a/nx.json
+++ b/nx.json
@@ -1,4 +1,6 @@
 {
+  "nxCloudAccessToken": "ZTRiZDM5NGItZWVlNy00MDZjLTgzNGYtYWFjN2M3ZTliNjdifHJlYWQtd3JpdGU=",
+  "nxCloudUrl": "https://cloud.nx.app",
   "npmScope": "kin-kinetic",
   "affected": {
     "defaultBase": "dev"


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/65d0252b9e4953a5ed64feba/workspaces/65d0254686fad55a3e75f316

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.